### PR TITLE
infrastructure for embedding adhocracy

### DIFF
--- a/meinberlin/templatetags/base_tags.py
+++ b/meinberlin/templatetags/base_tags.py
@@ -1,0 +1,8 @@
+from django import template
+from django.conf import settings
+register = template.Library()
+
+
+@register.simple_tag
+def settings_value(name):
+    return getattr(settings, name, "")

--- a/meinberlin_wagtail/settings/dev.py
+++ b/meinberlin_wagtail/settings/dev.py
@@ -13,6 +13,7 @@ SECRET_KEY = 'gy$z^$s1k*u=okx%5kqx*lg-u$l*yp6()pq(=yi(a)5bs35e30'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+ADHOCRACY_URL = 'http://localhost:6551'
 
 try:
     from .local import *

--- a/meinberlin_wagtail/static/js/meinberlin_wagtail.js
+++ b/meinberlin_wagtail/static/js/meinberlin_wagtail.js
@@ -1,0 +1,5 @@
+var adhocracyOrigin = document.body.dataset.adhocracyUrl;
+
+adhocracy.init(adhocracyOrigin, function(adhocracy) {
+    adhocracy.embed(".adhocracy_marker");
+});

--- a/meinberlin_wagtail/templates/base.html
+++ b/meinberlin_wagtail/templates/base.html
@@ -1,4 +1,4 @@
-{% load static wagtailuserbar wagtailcore_tags navigation %}
+{% load static wagtailuserbar wagtailcore_tags navigation base_tags %}
 
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
@@ -23,7 +23,7 @@
         {% endblock %}
     </head>
 
-    <body class="locale_de socialmediacounter">
+    <body class="locale_de socialmediacounter" data-adhocracy-url="{% settings_value "ADHOCRACY_URL" %}">
         {% wagtailuserbar %}
 
         <div class="container-portal-header">
@@ -113,6 +113,7 @@
         </div>
 
         {# Global javascript #}
+        <script type="text/javascript" src="{% settings_value "ADHOCRACY_URL" %}/static/js/AdhocracySDK.js"></script>
         <script type="text/javascript" src="{% static 'js/meinberlin_wagtail.js' %}"></script>
 
         {% block extra_js %}


### PR DESCRIPTION
This adds the code required to embed adhocracy. Now it should be sufficient to add an element with class `adhocracy_marker` anywhere on the page.
